### PR TITLE
Add tech stack badges for project tiles

### DIFF
--- a/index.html
+++ b/index.html
@@ -292,6 +292,13 @@
             background: color-mix(in srgb, var(--accent)12%, transparent);
         }
 
+        .badges {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 8px;
+            margin: 6px 0 0;
+        }
+
         .tile {
             background: var(--surface);
             border: 1px solid var(--border);
@@ -511,6 +518,14 @@
                             <a href="https://www.facebook.com/share/p/17KFWRUQa4/" target="_blank" rel="noopener">
                                 (Xem demo)
                             </a>
+                            <div class="badges">
+                                <span class="badge">Prisma</span>
+                                <span class="badge">PostgreSQL</span>
+                                <span class="badge">Node.js</span>
+                                <span class="badge">React Admin</span>
+                                <span class="badge">Deno</span>
+                                <span class="badge">Cloudflare</span>
+                            </div>
                             <ul>
                                 <li>Thiết kế và triển khai hệ thống bán vé và check-in đạt chuẩn chuyên nghiệp cho sự kiện
                                     cộng đồng quy mô lớn.</li>
@@ -526,6 +541,13 @@
                             <a href="https://worldlotho.com/staff" target="_blank" rel="noopener">
                                 (Xem demo)
                             </a>
+                            <div class="badges">
+                                <span class="badge">SonicJS</span>
+                                <span class="badge">Node.js</span>
+                                <span class="badge">Cloudflare</span>
+                                <span class="badge">HTML</span>
+                                <span class="badge">CSS</span>
+                            </div>
                             <ul>
                                 <li>Liên kết mỗi thẻ NFC với một trang hồ sơ cá nhân trực tuyến để xác thực tức thời.</li>
                                 <li>Thiết kế dashboard quản trị thân thiện giúp đội ngũ quản lý dữ liệu thành viên nhanh chóng.</li>
@@ -539,6 +561,9 @@
                             <a href="https://worldlotho.com" target="_blank" rel="noopener">
                                 (Xem live)
                             </a>
+                            <div class="badges">
+                                <span class="badge">Vanilla CSS</span>
+                            </div>
                             <ul>
                                 <li>Xây dựng giao diện landing page chuyển đổi cao với các khối nội dung rõ ràng.</li>
                                 <li>Tối ưu tốc độ tải trang, đạt điểm Lighthouse &gt; 90 cho cả desktop và mobile.</li>


### PR DESCRIPTION
## Summary
- add a reusable `.badges` layout to align tech stack chips under project cards
- list the relevant tools for each featured project via badge components

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d581a7b774832ba40e06a6d298f79f