### PR TITLE
Adjust education badges layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -324,6 +324,26 @@
             margin: 6px 0 0;
         }
 
+        .card-title {
+            display: flex;
+            flex-direction: column;
+            align-items: flex-start;
+            gap: 6px;
+            margin: 0 0 12px;
+        }
+
+        .card-title .badge {
+            margin: 0;
+        }
+
+        @media (min-width: 768px) {
+            .card-title {
+                flex-direction: row;
+                align-items: center;
+                gap: 10px;
+            }
+        }
+
         .tile {
             background: var(--surface);
             border: 1px solid var(--border);
@@ -544,11 +564,11 @@
             <div class="container">
                 <h2 class="section-title">Học vấn</h2>
                 <div class="card">
-                    <h3>ĐH Thủy Lợi - Phân hiệu TP.HCM <span class="badge">2025 - Hiện tại</span></h3>
+                    <h3 class="card-title">ĐH Thủy Lợi - Phân hiệu TP.HCM <span class="badge">2025 - Hiện tại</span></h3>
                     <p class="muted">Chuyên ngành Công nghệ thông tin</p>
                 </div>
                 <div class="card">
-                    <h3>Trung cấp nghề Nhân Đạo <span class="badge">2022 - 2024</span></h3>
+                    <h3 class="card-title">Trung cấp nghề Nhân Đạo <span class="badge">2022 - 2024</span></h3>
                     <p class="muted">Hệ trung cấp ngành Kỹ thuật máy tính</p>
                     <p class="muted">GPA: 3.8 / 4</p>
                 </div>
@@ -591,7 +611,7 @@
             <div class="container">
                 <h2 class="section-title">Kinh nghiệm</h2>
                 <div class="card">
-                    <h3>World Lọt Hố <span class="badge">2023 — Nay</span></h3>
+                    <h3 class="card-title">World Lọt Hố <span class="badge">2023 — Nay</span></h3>
                     <p class="muted">IT Specialist</p>
                     <ul>
                         <li>Phát triển và duy trì nhiều hệ thống để hỗ trợ các hoạt động của đội nhóm.</li>


### PR DESCRIPTION
## Summary
- keep card titles stacked on small screens so badges drop below the heading
- switch card titles to a row layout on wider viewports so badges stay inline on desktop

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d5868afe28832b859e1b23b4d6a645