### PR TITLE
Adjust education badge layout for mobile

### DIFF
--- a/index.html
+++ b/index.html
@@ -519,6 +519,17 @@
                 text-align: center;
             }
 
+            #education .card h3 {
+                display: flex;
+                flex-direction: column;
+                align-items: flex-start;
+                gap: 6px;
+            }
+
+            #education .card h3 .badge {
+                margin: 0;
+            }
+
             .meta {
                 width: 100%;
                 margin-inline: 0;


### PR DESCRIPTION
## Summary
- stack the education section badges below their headings on small screens to prevent overflow

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d8fc029674832ba6ad7b95f4eb6db4