### PR TITLE
Fix vertical flow for skills and project cards

### DIFF
--- a/index.html
+++ b/index.html
@@ -336,12 +336,14 @@
             list-style: none;
             margin: 0;
             padding: 0;
-            display: grid;
+            display: flex;
+            flex-direction: column;
             gap: 10px;
         }
 
         .skill-item {
-            display: flex;
+            display: grid;
+            grid-template-columns: 28px 1fr;
             align-items: center;
             gap: 10px;
             font-weight: 600;
@@ -422,19 +424,21 @@
             }
         }
       
-      .tile {
+        .tile {
             background: var(--surface);
             border: 1px solid var(--border);
             border-radius: var(--radius);
             overflow: hidden;
             box-shadow: 0 28px 35px -40px rgba(12, 15, 20, .4);
-            display: grid;
+            display: flex;
+            flex-direction: column;
         }
 
         .tile figure {
             margin: 0;
             position: relative;
             overflow: hidden;
+            flex-shrink: 0;
         }
 
         .tile img {
@@ -447,8 +451,12 @@
 
         .tile .body {
             padding: 20px;
-            display: grid;
-            gap: 10px;
+            display: flex;
+            flex-direction: column;
+            align-items: flex-start;
+            gap: 12px;
+            flex: 1;
+            width: 100%;
         }
 
         .tile h4 {
@@ -465,12 +473,17 @@
             display: grid;
             gap: var(--space);
             grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+            align-items: stretch;
+            grid-auto-rows: 1fr;
         }
 
         .projects ul {
             margin: 0;
             padding-left: 18px;
             color: var(--muted);
+            display: flex;
+            flex-direction: column;
+            gap: 8px;
         }
 
         .highlights {
@@ -528,6 +541,10 @@
             flex-wrap: wrap;
             gap: 10px;
             margin-top: 10px;
+        }
+
+        .tile .body .tech-icons {
+            margin-top: auto;
         }
 
         .tech-icon {


### PR DESCRIPTION
## Summary
- switch skill lists to a vertical flex column so items flow top-to-bottom without extra spacing
- update project card bodies to use a column flex layout for consistent stacking of content
- ensure skill items and project cards align evenly with grid-based rows and equal-height tiles

## Testing
- no tests were run (static site)

------
https://chatgpt.com/codex/tasks/task_e_68d904876d58832bb08ac878cc2f0807